### PR TITLE
Remove depencency on byte array for JsonEventSerializer. Fixes #32

### DIFF
--- a/src/DomainLib.EventStore.Testing/EventStoreEventsRepositoryTests.cs
+++ b/src/DomainLib.EventStore.Testing/EventStoreEventsRepositoryTests.cs
@@ -98,7 +98,7 @@ namespace DomainLib.EventStore.Testing
             string erroredEventData = null;
             Guid? erroredEventId = null;
 
-            void OnEventError(IEventPersistenceData e)
+            void OnEventError(IEventPersistenceData<byte[]> e)
             {
                 erroredEventCount++;
                 erroredEventData = Encoding.UTF8.GetString(e.EventData);
@@ -123,9 +123,9 @@ namespace DomainLib.EventStore.Testing
             });
         }
 
-        private IEventsRepository CreateRepository()
+        private IEventsRepository<byte[]> CreateRepository()
         {
-            var serializer = new JsonEventSerializer(Fakes.EventNameMap);
+            var serializer = new JsonBytesEventSerializer(Fakes.EventNameMap);
             var repo = new EventStoreEventsRepository(EventStoreConnection, serializer);
 
             return repo;

--- a/src/DomainLib.EventStore.Testing/SnapshotScenario.cs
+++ b/src/DomainLib.EventStore.Testing/SnapshotScenario.cs
@@ -15,7 +15,7 @@ namespace DomainLib.EventStore.Testing
         private readonly TestAggregateState _initialState;
         private EmbeddedEventStoreTest _test;
         private CommandDispatcher<TestCommand, TestEvent> _commandDispatcher;
-        private AggregateRepository<TestEvent> _aggregateRepository;
+        private AggregateRepository<TestEvent, byte[]> _aggregateRepository;
         private Guid _id;
         private List<TestEvent> _uncommittedEvents = new();
         private long _aggregateVersion = StreamVersion.NewStream;
@@ -94,13 +94,13 @@ namespace DomainLib.EventStore.Testing
 
             var registry = registryBuilder.Build();
 
-            var serializer = new JsonEventSerializer(registry.EventNameMap);
+            var serializer = new JsonBytesEventSerializer(registry.EventNameMap);
 
             _commandDispatcher = registry.CommandDispatcher;
             var snapshotRepository = new EventStoreSnapshotRepository(_test.EventStoreConnection, serializer);
             var eventsRepository = new EventStoreEventsRepository(_test.EventStoreConnection, serializer);
 
-            _aggregateRepository = new AggregateRepository<TestEvent>(eventsRepository, snapshotRepository, registry.EventDispatcher, registry.AggregateMetadataMap);
+            _aggregateRepository = AggregateRepository.Create(eventsRepository, snapshotRepository, registry.EventDispatcher, registry.AggregateMetadataMap);
         }
     }
 }

--- a/src/DomainLib.Persistence.EventStore/EventStoreEventDataExtensions.cs
+++ b/src/DomainLib.Persistence.EventStore/EventStoreEventDataExtensions.cs
@@ -6,12 +6,12 @@ namespace DomainLib.Persistence.EventStore
 {
     public static class EventStoreEventDataExtensions
     {
-        public static EventData ToEventData(this IEventSerializer @eventSerializer, object @event, string eventNameOverride = null, params KeyValuePair<string, string>[] additionalMetadata)
+        public static EventData ToEventData(this IEventSerializer<byte[]> @eventSerializer, object @event, string eventNameOverride = null, params KeyValuePair<string, string>[] additionalMetadata)
         {
             var eventPersistenceData = eventSerializer.GetPersistenceData(@event, eventNameOverride, additionalMetadata);
             return new EventData(eventPersistenceData.EventId,
                                  eventPersistenceData.EventName,
-                                 eventPersistenceData.IsJsonBytes,
+                                 eventPersistenceData.IsJson,
                                  eventPersistenceData.EventData,
                                  eventPersistenceData.EventMetadata);
         }

--- a/src/DomainLib.Persistence.EventStore/EventStoreEventPersistenceData.cs
+++ b/src/DomainLib.Persistence.EventStore/EventStoreEventPersistenceData.cs
@@ -4,24 +4,24 @@ using EventStore.ClientAPI;
 
 namespace DomainLib.Persistence.EventStore
 {
-    public class EventStoreEventPersistenceData : IEventPersistenceData
+    public class EventStoreEventPersistenceData : IEventPersistenceData<byte[]>
     {
         private EventStoreEventPersistenceData(Guid eventId, string eventName, bool isJsonBytes, byte[] eventData, byte[] eventMetadata)
         {
             EventId = eventId;
             EventName = eventName;
-            IsJsonBytes = isJsonBytes;
+            IsJson = isJsonBytes;
             EventData = eventData;
             EventMetadata = eventMetadata;
         }
 
         public Guid EventId { get; }
         public string EventName { get; }
-        public bool IsJsonBytes { get; }
+        public bool IsJson { get; }
         public byte[] EventData { get; }
         public byte[] EventMetadata { get; }
 
-        public static IEventPersistenceData FromRecordedEvent(RecordedEvent recordedEvent)
+        public static IEventPersistenceData<byte[]> FromRecordedEvent(RecordedEvent recordedEvent)
         {
             return new EventStoreEventPersistenceData(recordedEvent.EventId,
                                                       recordedEvent.EventType,

--- a/src/DomainLib.Persistence.EventStore/EventStoreEventsRepository.cs
+++ b/src/DomainLib.Persistence.EventStore/EventStoreEventsRepository.cs
@@ -9,14 +9,14 @@ using System.Threading.Tasks;
 
 namespace DomainLib.Persistence.EventStore
 {
-    public class EventStoreEventsRepository : IEventsRepository
+    public class EventStoreEventsRepository : IEventsRepository<byte[]>
     {
         private static readonly ILogger<EventStoreEventsRepository> Log = Logger.CreateFor<EventStoreEventsRepository>();
         private readonly IEventStoreConnection _connection;
-        private readonly IEventSerializer _serializer;
+        private readonly IEventSerializer<byte[]> _serializer;
         private const int MaxWriteBatchSize = 4095;
 
-        public EventStoreEventsRepository(IEventStoreConnection connection, IEventSerializer serializer)
+        public EventStoreEventsRepository(IEventStoreConnection connection, IEventSerializer<byte[]> serializer)
         {
             _connection = connection ?? throw new ArgumentNullException(nameof(connection));
             _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
@@ -104,7 +104,7 @@ namespace DomainLib.Persistence.EventStore
             return writeResult.NextExpectedVersion;
         }
 
-        public async Task<IList<TEvent>> LoadEventsAsync<TEvent>(string streamName, long startPosition = 0, Action<IEventPersistenceData> onEventError = null)
+        public async Task<IList<TEvent>> LoadEventsAsync<TEvent>(string streamName, long startPosition = 0, Action<IEventPersistenceData<byte[]>> onEventError = null)
         {
             if (streamName == null) throw new ArgumentNullException(nameof(streamName));
             var sliceStartPosition = startPosition;

--- a/src/DomainLib.Persistence.EventStore/EventStoreSnapshotRepository.cs
+++ b/src/DomainLib.Persistence.EventStore/EventStoreSnapshotRepository.cs
@@ -14,9 +14,9 @@ namespace DomainLib.Persistence.EventStore
         private const string SnapshotEventName = "Snapshot";
         private static readonly ILogger<EventStoreSnapshotRepository> Log = Logger.CreateFor<EventStoreSnapshotRepository>();
         private readonly IEventStoreConnection _connection;
-        private readonly IEventSerializer _serializer;
+        private readonly IEventSerializer<byte[]> _serializer;
 
-        public EventStoreSnapshotRepository(IEventStoreConnection connection, IEventSerializer serializer)
+        public EventStoreSnapshotRepository(IEventStoreConnection connection, IEventSerializer<byte[]> serializer)
         {
             _connection = connection;
             _serializer = serializer;

--- a/src/DomainLib.Persistence/IEventsRepository.cs
+++ b/src/DomainLib.Persistence/IEventsRepository.cs
@@ -5,9 +5,9 @@ using DomainLib.Serialization;
 
 namespace DomainLib.Persistence
 {
-    public interface IEventsRepository
+    public interface IEventsRepository<out TRawData>
     {
         Task<long> SaveEventsAsync<TEvent>(string streamName, long expectedStreamVersion, IEnumerable<TEvent> events);
-        Task<IList<TEvent>> LoadEventsAsync<TEvent>(string streamName, long startPosition = 0, Action<IEventPersistenceData> onEventError = null);
+        Task<IList<TEvent>> LoadEventsAsync<TEvent>(string streamName, long startPosition = 0, Action<IEventPersistenceData<TRawData>> onEventError = null);
     }
 }

--- a/src/DomainLib.Projections.Sqlite.Tests/InMemoryDbTests.cs
+++ b/src/DomainLib.Projections.Sqlite.Tests/InMemoryDbTests.cs
@@ -1,5 +1,4 @@
 ﻿using Dapper;
-using DomainLib.Aggregates;
 using DomainLib.Common;
 using DomainLib.Projections.Sql;
 using DomainLib.Projections.Sql.Tests.Fakes;
@@ -110,16 +109,13 @@ namespace DomainLib.Projections.Sqlite.Tests
 
             var registry = projectionRegistryBuilder.Build();
 
-            // TODO: EventNameMap isn't actually used here as we deserialize differently on the read side.
-            // We need to fix this so that we don't have to pass an empty instance in
-            var serializer = new JsonEventSerializer(new EventNameMap());
             var eventPublisher = new FakeJsonEventPublisher();
             _publisher = eventPublisher;
 
             var eventDispatcher = new EventDispatcher<object>(eventPublisher,
                                                               registry.EventProjectionMap,
                                                               registry.EventContextMap,
-                                                              serializer,
+                                                              new JsonEventDeserializer(),
                                                               registry.EventNameMap,
                                                               EventDispatcherConfiguration.ReadModelDefaults with {
                                                                   ProjectionHandlerTimeout = TimeSpan.FromMinutes(5)});

--- a/src/DomainLib.Projections.Tests/SqlProjectionScenario.cs
+++ b/src/DomainLib.Projections.Tests/SqlProjectionScenario.cs
@@ -65,14 +65,13 @@ namespace DomainLib.Projections.Sql.Tests
                            .ExecutesCustomSql(DeleteCustomSqlEvent.CustomSqlText);
 
             var registry = registryBuilder.Build();
-            var serializer = new JsonEventSerializer(new EventNameMap());
             var dispatcherConfig = EventDispatcherConfiguration.ReadModelDefaults with { ProjectionHandlerTimeout =
                                        TimeSpan.FromHours(2)};
 
             var dispatcher = new EventDispatcher<object>(Publisher,
                                                          registry.EventProjectionMap,
                                                          registry.EventContextMap,
-                                                         serializer,
+                                                         new JsonEventDeserializer(),
                                                          registry.EventNameMap,
                                                          dispatcherConfig);
 

--- a/src/DomainLib.Projections/EventDispatcher.cs
+++ b/src/DomainLib.Projections/EventDispatcher.cs
@@ -15,20 +15,20 @@ namespace DomainLib.Projections
         private readonly EventProjectionMap _projectionMap;
         private readonly EventContextMap _eventContextMap;
         private readonly EventDispatcherConfiguration _configuration;
-        private readonly IEventSerializer _serializer;
+        private readonly IEventDeserializer _deserializer;
         private readonly IProjectionEventNameMap _projectionEventNameMap;
 
         public EventDispatcher(IEventPublisher<byte[]> publisher,
                                EventProjectionMap projectionMap,
                                EventContextMap eventContextMap,
-                               IEventSerializer serializer,
+                               IEventDeserializer serializer,
                                IProjectionEventNameMap projectionEventNameMap,
                                EventDispatcherConfiguration configuration)
         {
             _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
             _projectionMap = projectionMap ?? throw new ArgumentNullException(nameof(projectionMap));
             _eventContextMap = eventContextMap ?? throw new ArgumentNullException(nameof(eventContextMap));
-            _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+            _deserializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
             _projectionEventNameMap =
                 projectionEventNameMap ?? throw new ArgumentNullException(nameof(projectionEventNameMap));
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
@@ -79,7 +79,7 @@ namespace DomainLib.Projections
                 TEventBase @event;
                 try
                 {
-                    @event = _serializer.DeserializeEvent<TEventBase>(eventData, eventType, type);
+                    @event = _deserializer.DeserializeEvent<TEventBase>(eventData, eventType, type);
                 }
                 catch (Exception e)
                 {

--- a/src/DomainLib.Serialization.Json.Tests/MetadataSerializationTests.cs
+++ b/src/DomainLib.Serialization.Json.Tests/MetadataSerializationTests.cs
@@ -120,7 +120,7 @@ namespace DomainLib.Serialization.Json.Tests
         [Test]
         public void SerializationWorksWhenNoMetadataContext()
         {
-            var serializer = new JsonEventSerializer(Fakes.EventNameMap);
+            var serializer = new JsonBytesEventSerializer(Fakes.EventNameMap);
 
             var @event = new TestEvent("Some Value");
             var persistenceData = serializer.GetPersistenceData(@event);
@@ -132,7 +132,7 @@ namespace DomainLib.Serialization.Json.Tests
         public void EmptyMetaDataContextDoesNotIncludeDefaults()
         {
             var emptyMetadataContext = EventMetadataContext.CreateEmpty();
-            var serializer = new JsonEventSerializer(Fakes.EventNameMap);
+            var serializer = new JsonBytesEventSerializer(Fakes.EventNameMap);
             serializer.UseMetaDataContext(emptyMetadataContext);
 
             emptyMetadataContext.AddEntry(StaticKey, StaticValue);
@@ -160,12 +160,12 @@ namespace DomainLib.Serialization.Json.Tests
             Assert.That(metadata[MetadataKeys.UtcDateTime], Is.Not.Null);
         }
 
-        private static IEventSerializer CreateJsonSerializerWithMetadata(Action<EventMetadataContext> applyCustomMetadata = null)
+        private static IEventSerializer<byte[]> CreateJsonSerializerWithMetadata(Action<EventMetadataContext> applyCustomMetadata = null)
         {
 
 
             var metadataContext = EventMetadataContext.CreateWithDefaults(TestServiceName);
-            var serializer = new JsonEventSerializer(Fakes.EventNameMap);
+            var serializer = new JsonBytesEventSerializer(Fakes.EventNameMap);
             serializer.UseMetaDataContext(metadataContext);
 
             applyCustomMetadata?.Invoke(metadataContext);
@@ -173,7 +173,7 @@ namespace DomainLib.Serialization.Json.Tests
             return serializer;
         }
 
-        private static IDictionary<string, string> GetMetadataFromEventPersistenceData(IEventPersistenceData persistenceData)
+        private static IDictionary<string, string> GetMetadataFromEventPersistenceData(IEventPersistenceData<byte[]> persistenceData)
         {
             return JsonSerializer.Deserialize<List<KeyValuePair<string, string>>>(persistenceData.EventMetadata)
                                  .ToDictionary(x => x.Key, x => x.Value);

--- a/src/DomainLib.Serialization.Json/JsonBytesEventSerializer.cs
+++ b/src/DomainLib.Serialization.Json/JsonBytesEventSerializer.cs
@@ -1,0 +1,18 @@
+﻿using System.Text.Json;
+using DomainLib.Aggregates;
+
+namespace DomainLib.Serialization.Json
+{
+    public class JsonBytesEventSerializer : JsonEventSerializer<byte[]>
+    {
+        public JsonBytesEventSerializer(IEventNameMap eventNameMap) : 
+            base(eventNameMap, new ByteArrayEventSerializationAdapter())
+        {
+        }
+
+        public JsonBytesEventSerializer(IEventNameMap eventNameMap, JsonSerializerOptions options) : 
+            base(eventNameMap, new ByteArrayEventSerializationAdapter(), options)
+        {
+        }
+    }
+}

--- a/src/DomainLib.Serialization.Json/JsonEventDeserializer.cs
+++ b/src/DomainLib.Serialization.Json/JsonEventDeserializer.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Text.Json;
+
+namespace DomainLib.Serialization.Json
+{
+    public class JsonEventDeserializer : IEventDeserializer
+    {
+        public TEventBase DeserializeEvent<TEventBase>(ReadOnlySpan<byte> eventData, string eventName, Type eventType, JsonSerializerOptions options = null)
+        {
+            if (eventData == null) throw new ArgumentNullException(nameof(eventData));
+            if (eventName == null) throw new ArgumentNullException(nameof(eventName));
+            if (eventType == null) throw new ArgumentNullException(nameof(eventType));
+
+            try
+            {
+                var evt = JsonSerializer.Deserialize(eventData, eventType, options);
+
+                if (evt is TEventBase @event)
+                {
+                    return @event;
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new EventDeserializeException("Unable to deserialize event", ex);
+            }
+
+            var runtTimeType = typeof(TEventBase);
+            throw new InvalidEventTypeException($"Cannot cast event of type {eventName} to {runtTimeType.FullName}", eventName, runtTimeType.FullName);
+        }
+    }
+}

--- a/src/DomainLib.Serialization.Json/JsonEventPersistenceData.cs
+++ b/src/DomainLib.Serialization.Json/JsonEventPersistenceData.cs
@@ -2,21 +2,21 @@
 
 namespace DomainLib.Serialization.Json
 {
-    public readonly struct JsonEventPersistenceData : IEventPersistenceData
+    public readonly struct JsonEventPersistenceData<TRawData> : IEventPersistenceData<TRawData>
     {
-        public JsonEventPersistenceData(Guid eventId, string eventName, byte[] eventData, byte[] eventMetadata) : this()
+        public JsonEventPersistenceData(Guid eventId, string eventName, TRawData eventData, TRawData eventMetadata) : this()
         {
             EventId = eventId;
             EventName = eventName;
-            IsJsonBytes = true;
+            IsJson = true;
             EventData = eventData;
             EventMetadata = eventMetadata;
         }
 
         public Guid EventId { get; }
         public string EventName { get; }
-        public bool IsJsonBytes { get; }
-        public byte[] EventData { get; }
-        public byte[] EventMetadata { get; }
+        public bool IsJson { get; }
+        public TRawData EventData { get; }
+        public TRawData EventMetadata { get; }
     }
 }

--- a/src/DomainLib.Serialization.Json/JsonStringEventSerializer.cs
+++ b/src/DomainLib.Serialization.Json/JsonStringEventSerializer.cs
@@ -1,0 +1,18 @@
+﻿using System.Text.Json;
+using DomainLib.Aggregates;
+
+namespace DomainLib.Serialization.Json
+{
+    public class JsonStringEventSerializer : JsonEventSerializer<string>
+    {
+        public JsonStringEventSerializer(IEventNameMap eventNameMap) : 
+            base(eventNameMap, new Utf8StringEventSerializationAdapter())
+        {
+        }
+
+        public JsonStringEventSerializer(IEventNameMap eventNameMap, JsonSerializerOptions options) :
+            base(eventNameMap, new Utf8StringEventSerializationAdapter(), options)
+        {
+        }
+    }
+}

--- a/src/DomainLib.Serialization/ByteArrayEventSerializationAdapter.cs
+++ b/src/DomainLib.Serialization/ByteArrayEventSerializationAdapter.cs
@@ -1,0 +1,15 @@
+﻿namespace DomainLib.Serialization
+{
+    public class ByteArrayEventSerializationAdapter : IEventSerializationAdapter<byte[]>
+    {
+        public byte[] FromRawData(byte[] rawEventData)
+        {
+            return rawEventData;
+        }
+
+        public byte[] ToRawData(byte[] bytes)
+        {
+            return bytes;
+        }
+    }
+}

--- a/src/DomainLib.Serialization/IEventDeserializer.cs
+++ b/src/DomainLib.Serialization/IEventDeserializer.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Text.Json;
+
+namespace DomainLib.Serialization
+{
+    public interface IEventDeserializer
+    {
+        TEventBase DeserializeEvent<TEventBase>(ReadOnlySpan<byte> eventData, string eventName, Type eventType, JsonSerializerOptions options = null);
+    }
+}

--- a/src/DomainLib.Serialization/IEventPersistenceData.cs
+++ b/src/DomainLib.Serialization/IEventPersistenceData.cs
@@ -2,12 +2,12 @@
 
 namespace DomainLib.Serialization
 {
-    public interface IEventPersistenceData
+    public interface IEventPersistenceData<out TRawData>
     {
         Guid EventId { get; }
         string EventName { get; }
-        bool IsJsonBytes { get; }
-        byte[] EventData { get; }
-        byte[] EventMetadata { get; }
+        bool IsJson { get; }
+        TRawData EventData { get; }
+        TRawData EventMetadata { get; }
     }
 }

--- a/src/DomainLib.Serialization/IEventSerializationAdapter.cs
+++ b/src/DomainLib.Serialization/IEventSerializationAdapter.cs
@@ -1,0 +1,8 @@
+﻿namespace DomainLib.Serialization
+{
+    public interface IEventSerializationAdapter<TRawData>
+    {
+        byte[] FromRawData(TRawData rawEventData);
+        TRawData ToRawData(byte[] bytes);
+    }
+}

--- a/src/DomainLib.Serialization/IEventSerializer.cs
+++ b/src/DomainLib.Serialization/IEventSerializer.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 
 namespace DomainLib.Serialization
 {
-    public interface IEventSerializer
+    public interface IEventSerializer<TRawData>
     {
-        IEventPersistenceData  GetPersistenceData(object @event, string eventNameOverride = null, params KeyValuePair<string, string>[] additionalMetadata);
-        TEvent DeserializeEvent<TEvent>(byte[] eventData, string eventName, Type typeOverride = null);
+        IEventPersistenceData<TRawData> GetPersistenceData(object @event, string eventNameOverride = null, params KeyValuePair<string, string>[] additionalMetadata);
+        TEvent DeserializeEvent<TEvent>(TRawData eventData, string eventName, Type typeOverride = null);
         void UseMetaDataContext(EventMetadataContext metadataContext);
-        Dictionary<string, string> DeserializeMetadata(byte[] metadataBytes);
+        Dictionary<string, string> DeserializeMetadata(TRawData rawMetadata);
     }
 }

--- a/src/DomainLib.Serialization/Utf8StringEventSerializationAdapter.cs
+++ b/src/DomainLib.Serialization/Utf8StringEventSerializationAdapter.cs
@@ -1,0 +1,17 @@
+﻿using System.Text;
+
+namespace DomainLib.Serialization
+{
+    public class Utf8StringEventSerializationAdapter : IEventSerializationAdapter<string>
+    {
+        public byte[] FromRawData(string rawEventData)
+        {
+            return Encoding.UTF8.GetBytes(rawEventData);
+        }
+
+        public string ToRawData(byte[] bytes)
+        {
+            return Encoding.UTF8.GetString(bytes);
+        }
+    }
+}

--- a/src/Examples/Shopping.Infrastructure.Tests/ShoppingCartInfrastructureTests.cs
+++ b/src/Examples/Shopping.Infrastructure.Tests/ShoppingCartInfrastructureTests.cs
@@ -40,14 +40,14 @@ namespace Shopping.Infrastructure.Tests
 
             var eventsToPersist = events1.Concat(events2).ToList();
 
-            var serializer = new JsonEventSerializer(aggregateRegistry.EventNameMap);
+            var serializer = new JsonBytesEventSerializer(aggregateRegistry.EventNameMap);
             var eventsRepository = new EventStoreEventsRepository(EventStoreConnection, serializer);
             var snapshotRepository = new EventStoreSnapshotRepository(EventStoreConnection, serializer);
 
-            var aggregateRepository = new AggregateRepository<IDomainEvent>(eventsRepository, 
-                                                                            snapshotRepository, 
-                                                                            aggregateRegistry.EventDispatcher,
-                                                                            aggregateRegistry.AggregateMetadataMap);
+            var aggregateRepository = AggregateRepository.Create(eventsRepository,
+                                                                 snapshotRepository,
+                                                                 aggregateRegistry.EventDispatcher,
+                                                                 aggregateRegistry.AggregateMetadataMap);
 
             var nextEventVersion = await aggregateRepository.SaveAggregate<ShoppingCartState>(newState2.Id.ToString(),
                                                                                               ExpectedVersion.NoStream,


### PR DESCRIPTION
Also split out the deserialization step so that it can be used on the projections side without needing an instance of EventNameMap